### PR TITLE
1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 1.2.1
+
+### Added
+
+- Exported `ErrorObjectParams` interface for the constructor parameter type
+- `clone()` method to create a copy of an existing `ErrorObject`
+- `toJSON()` method for clean serialization (excludes internal discriminator and inherited `Error` fields)
+- `LOG_METHOD` now accepts `null` to disable logging entirely
+
+### Changed
+
+- `generic()` is now a regular static method instead of an arrow function, for consistency with `withTag()`
+- Simplified `toString()` — removed redundant optional chaining and nested ternaries
+- `toString()` no longer suppresses code via substring match (`domain.includes(code)`), uses exact equality instead
+- `toDebugString()` JSON replacer broken out for readability
+- Constructor `raw` → `name`/`stack` extraction logic cleaned up with a helper function
+
+### Deprecated
+
+- `new()` — use `clone()` instead
+
+## 1.2.0
+
+### Breaking Changes
+
+- Renamed static constants: `DEFAULT_GENERIC_CODE` → `GENERIC_CODE`, `DEFAULT_GENERIC_MESSAGE` → `GENERIC_MESSAGE`, `DEFAULT_GENERIC_TAG` → `GENERIC_TAG`
+- Removed `DEFAULT_DOMAIN` — domain is no longer auto-populated from a static default
+- Removed `toVerboseString()` and `verboseLog()` — use `toDebugString()` and `debugLog()` instead (debug output now includes all properties via `JSON.stringify`)
+
+### Added
+
+- `LOG_METHOD` static property to override the default log function (default: `console.log`)
+- `INCLUDE_DOMAIN_IN_STRING` static property to control whether `toString()` includes the domain
+- `INCLUDE_CODE_IN_STRING` static property to control whether `toString()` includes the code
+- `_log()` is now `protected` instead of `private`, allowing subclasses to override logging behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,85 @@
 
 ## 1.2.1
 
+### Breaking Changes
+
+- Removed `toVerboseString()` and `verboseLog()` — use `toDebugString()` and `debugLog()` instead
+
 ### Added
 
-- Exported `ErrorObjectParams` interface for the constructor parameter type
-- `clone()` method to create a copy of an existing `ErrorObject`
-- `toJSON()` method for clean serialization (excludes internal discriminator and inherited `Error` fields)
-- `LOG_METHOD` now accepts `null` to disable logging entirely
+- `INCLUDE_DOMAIN_IN_STRING` static property to control whether `toString()` includes the domain (default: `false`)
+- `INCLUDE_CODE_IN_STRING` static property to control whether `toString()` includes the code (default: `true`)
 
 ### Changed
 
-- `generic()` is now a regular static method instead of an arrow function, for consistency with `withTag()`
-- Simplified `toString()` — removed redundant optional chaining and nested ternaries
-- `toString()` no longer suppresses code via substring match (`domain.includes(code)`), uses exact equality instead
-- `toDebugString()` JSON replacer broken out for readability
-- Constructor `raw` → `name`/`stack` extraction logic cleaned up with a helper function
-
-### Deprecated
-
-- `new()` — use `clone()` instead
+- `toDebugString()` now uses `JSON.stringify(this, ...)` to include all properties dynamically, prefixed with `[DEBUG]`
+- `toString()` updated to respect `INCLUDE_DOMAIN_IN_STRING` and `INCLUDE_CODE_IN_STRING`
 
 ## 1.2.0
 
 ### Breaking Changes
 
-- Renamed static constants: `DEFAULT_GENERIC_CODE` → `GENERIC_CODE`, `DEFAULT_GENERIC_MESSAGE` → `GENERIC_MESSAGE`, `DEFAULT_GENERIC_TAG` → `GENERIC_TAG`
-- Removed `DEFAULT_DOMAIN` — domain is no longer auto-populated from a static default
-- Removed `toVerboseString()` and `verboseLog()` — use `toDebugString()` and `debugLog()` instead (debug output now includes all properties via `JSON.stringify`)
+- Renamed static constants: `DEFAULT_GENERIC_CODE` → `GENERIC_CODE`, `DEFAULT_GENERIC_MESSAGE` → `GENERIC_MESSAGE`,
+  `DEFAULT_GENERIC_TAG` → `GENERIC_TAG`
+- Removed `DEFAULT_DOMAIN` — domain is no longer autopopulated from a static default
 
 ### Added
 
 - `LOG_METHOD` static property to override the default log function (default: `console.log`)
-- `INCLUDE_DOMAIN_IN_STRING` static property to control whether `toString()` includes the domain
-- `INCLUDE_CODE_IN_STRING` static property to control whether `toString()` includes the code
+
+### Changed
+
 - `_log()` is now `protected` instead of `private`, allowing subclasses to override logging behavior
+
+## 1.1.9
+
+### Changed
+
+- `_log()` changed from `private` to `protected`
+
+## 1.1.8
+
+### Breaking Changes
+
+- Removed `nextErrors` property and `setNextErrors()` method
+- Removed multi-error logging in `_log()` (no longer iterates over `nextErrors`)
+
+### Changed
+
+- `toVerboseString()` simplified to `toDebugString()` + `JSON.stringify(this.raw)`
+- Fixed `Object.setPrototypeOf` to use `new.target.prototype` for proper subclass `instanceof` support
+- `isErrorObject()` now delegates to `ErrorObject.is()` instead of duplicating the check
+- Cleaned up JSDoc comments
+
+## 1.1.7
+
+### Breaking Changes
+
+- Removed `SHOW_ERROR_LOGS` static property
+- Removed `fallback()` factory, `isFallback()` method, and `DEFAULT_FALLBACK_TAG`
+- Removed `summary` property and `processingErrors` / `setProcessingErrors()`
+
+### Added
+
+- `__isErrorObjectTypeDiscriminator` readonly property for type discrimination
+- `ErrorObject.is()` static type guard
+- `isErrorObject()` standalone type guard function
+- JSDoc for `withTag()`
+
+### Changed
+
+- `generic()` now uses `new this(...)` instead of `new ErrorObject(...)` for correct subclass support
+- `nextErrors` type changed to `this[]`
+- Code reformatted (single quotes → double quotes, indentation cleanup)
+
+## 1.1.6
+
+Version bump to serve as a clean dependency for `@smbcheeky/error-object-from-payload`.
+
+## 1.1.5
+
+### Breaking Changes
+
+- Removed `.fromPayload()` static method and all builder/utils code — extracted
+  to [@smbcheeky/error-object-from-payload](https://github.com/SMBCheeky/error-object-from-payload)
+- Removed all exported utility types (`ErrorObjectBuildOptions`, `ErrorObjectProcessingError`, `ErrorSummary`, etc.)

--- a/README.md
+++ b/README.md
@@ -4,110 +4,224 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/smbcheeky/error-object)](https://github.com/smbcheeky/error-object)
 [![GitHub stars](https://img.shields.io/github/stars/smbcheeky/error-object)](https://img.shields.io/github/stars/smbcheeky/error-object)
 
+# ErrorObject
+
+A lightweight `Error` subclass for structured, chainable error handling in JavaScript and TypeScript. Errors that can be
+both thrown and returned with built-in type guards, chainable setters, and logging.
+
 ## Installation
 
-`npm install @smbcheeky/error-object`
+```bash
+npm install @smbcheeky/error-object
+```
 
-`yarn add @smbcheeky/error-object`
+```bash
+yarn add @smbcheeky/error-object
+```
 
-## Description
+## Why ErrorObject?
 
-The ErrorObject class is made to extend `Error` enabling type guard checks like `errorObject instanceof Error`,
-`errorObject instanceof ErrorObject`, ErrorObject.is() and isErrorObject(). The `ErrorObject` class is backwards
-compatible with `Error` and introduces a few new features:
+`ErrorObject` extends `Error`, so it works everywhere a regular `Error` does (`instanceof Error`, `try/catch`, etc.)
+while adding structure and ergonomics:
 
-- It can be thrown or returned, you choose.
-- It can be valid only if it contains a `code` and a `message` values
-- Intuitive type guards which help narrow down the type of JS objects
-- It can have a numberCode, not just a string code
-- set default values for the generic error objects via `ErrorObject.DEFAULT_GENERIC_CODE` and
-  `ErrorObject.DEFAULT_GENERIC_MESSAGE`
-- set a default domain for all errors via `ErrorObject.DEFAULT_DOMAIN`
-- Use `ErrorObject.generic()` or `ErrorObject.withTag('TAG')` to create an error from thin air
-- Use `.isGeneric()`, and `.hasTag()` to check if the error is a generic error or has a specific tag
-- Chain call setters like `.setCode()`, `.setNumberCode()`, `.setMessage()`, `.setDetails()`, `.setDomain()`,
-  `.setTag()` to modify the error
-  object at any moment
-- Setters can receive a value or a transform function, facilitating access to the current value while you modify the
-  property
-- Chain logs like `.log(tag)`, `.debugLog(tag)`, `.verboseLog(tag)` to log information about the error object
-  inline
-- Use `.description()` or `.toString()` to get a human-readable description of the error
-- Use `details`, `domain` and `tag` to customize the error object and help easily distinguish between different
-  errors
+- **Throw or return** — use whichever pattern fits your codebase
+- **Type guards** — `isErrorObject()`, `ErrorObject.is()`, and `instanceof` all work for narrowing types
+- **Structured properties** — `code`, `message`, `numberCode`, `details`, `domain`, `tag`, and `raw`
+- **Chainable setters** — modify any property inline with `.setCode()`, `.setMessage()`, etc.
+- **Setters accept transforms** — pass a function to access the current value while modifying it
+- **Built-in logging** — `.log(tag)` and `.debugLog(tag)` for inline logging
+- **Subclass-friendly** — works correctly with `extends ErrorObject`
 
-## Override default log method (default is `console.log`)
-
-To override the default log method, set the static property `LOG_METHOD` to a function that accepts any number of
-arguments and returns nothing. The default log method is `console.log`.
-
-## Override default generic error code and message
-
-To override the default generic error code and message, set the static properties `GENERIC_CODE` and `GENERIC_MESSAGE`.
-
-## new ErrorObjectFromPayload(payload, options)
-
-To parse errors from any payload, check
-out [@smbcheeky/error-object-from-payload](https://github.com/SMBCheeky/error-object-from-payload).
-
-## Usage & Examples
-
-You can find examples in the [playground](https://github.com/SMBCheeky/error-object/blob/main/playground/index.ts) file.
+## Quick Start
 
 ```typescript
-new ErrorObject({
-  code: "",
-  message: "Something went wrong.",
+import { ErrorObject, isErrorObject, ErrorObjectParams } from "@smbcheeky/error-object";
+
+// Create an error
+const error = new ErrorObject({
+  code: "auth/invalid-token",
+  message: "Your session has expired.",
   domain: "auth",
-}).debugLog("LOG");
+});
 
-// [LOG] Something went wrong [auth]
-// {
-//   "code": "",
-//   "message": "Something went wrong",
-//   "domain": "auth"
-// }
+// Chain setters and log inline
+error
+.setDetails("Please sign in again.")
+.setNumberCode(401)
+.debugLog("AUTH");
+
+// [AUTH] Your session has expired. [auth/invalid-token]
+// [DEBUG] { "code": "auth/invalid-token", "numberCode": 401, ... }
 ```
+
+## Creating Errors
 
 ```typescript
-const foo = (): { success: true } | ErrorObject => {
-  return { success: true };
-};
+// From explicit properties
+new ErrorObject({ code: "not-found", message: "User not found." });
 
-const fooError = (): { success: true } | ErrorObject => {
-  return ErrorObject.generic();
-};
+// Generic error (uses configurable defaults)
+ErrorObject.generic();
 
-const result1 = foo();
-if (isErrorObject(result1)) {
-  result1;
-  result1.code;
-  console.log("result1 is ErrorObject");
-  return;
-}
-result1;
-// result1.code; // triggers a type error
-console.log("result1 is not ErrorObject");
+// Generic error with a tag
+ErrorObject.withTag("network-timeout");
 
-const result2 = foo();
-if (result2 instanceof ErrorObject) {
-  result2;
-  result2.code;
-  console.log("result2 is ErrorObject");
-  return;
-}
-result2;
-// result2.code; // triggers a type error
-console.log("result2 is not ErrorObject");
-
-const result3 = fooError();
-if (ErrorObject.is(result3)) {
-  result3;
-  result3.code;
-  console.log("result3 is ErrorObject");
-  return;
-}
-result3;
-// result3.code; // triggers a type error
-console.log("result3 is not ErrorObject");
+// Clone an existing error
+existingError.clone();
+// .new() also works but is deprecated in favor of .clone()
 ```
+
+## Type Guards
+
+All three approaches narrow the type correctly in TypeScript:
+
+```typescript
+const result: { success: true } | ErrorObject = someFn();
+
+// Option 1: standalone function
+if (isErrorObject(result)) {
+  result.code; // TypeScript knows this is ErrorObject
+  return;
+}
+
+// Option 2: static method
+if (ErrorObject.is(result)) {
+  result.code;
+  return;
+}
+
+// Option 3: instanceof
+if (result instanceof ErrorObject) {
+  result.code;
+  return;
+}
+
+result; // TypeScript knows this is { success: true }
+```
+
+## Chainable Setters
+
+Every setter returns `this`, so you can chain them. Each setter accepts either a value or a transform function:
+
+```typescript
+ErrorObject.generic()
+.setCode("upload/too-large")
+.setMessage("File exceeds the size limit.")
+.setDomain("storage")
+.setNumberCode(413)
+.setDetails("Maximum file size is 10MB.")
+.setTag("upload-validation")
+.setRaw(originalError);
+
+// Transform function — access the current value
+error.setMessage((old) => `${old} Please try again.`);
+```
+
+## Properties
+
+| Property     | Type     | Required | Description                                          |
+|--------------|----------|----------|------------------------------------------------------|
+| `code`       | `string` | Yes      | Identifier for the error, ideally human-readable     |
+| `message`    | `string` | Yes      | Primary error message                                |
+| `numberCode` | `number` | No       | Numeric code (e.g. HTTP status)                      |
+| `details`    | `string` | No       | Extended description, suitable for showing to users  |
+| `domain`     | `string` | No       | Category grouping (e.g. `"auth"`, `"storage"`)       |
+| `tag`        | `string` | No       | Finer-grained label for filtering or identification  |
+| `raw`        | `any`    | No       | Original error or payload used to create this object |
+
+The constructor accepts an `ErrorObjectParams` object, which is exported for use in wrapper functions and utilities.
+
+## Logging
+
+`.log(tag)` outputs `toString()`, `.debugLog(tag)` outputs `toDebugString()` which includes a full JSON dump:
+
+```typescript
+new ErrorObject({ code: "timeout", message: "Request timed out.", domain: "api" })
+.log("NET")
+.debugLog("NET");
+
+// [NET] Request timed out. [api/timeout]
+// [NET] Request timed out. [api/timeout]
+// [DEBUG] { "code": "timeout", "message": "Request timed out.", "domain": "api" }
+```
+
+Both methods return `this` so they can be chained inline.
+
+## Tag Checks
+
+```typescript
+const error = ErrorObject.generic();
+
+error.isGeneric();   // true — checks if tag matches GENERIC_TAG
+error.hasTag();      // true — checks if any tag is set
+error.hasTag("foo"); // false — checks for a specific tag
+```
+
+## Serialization
+
+`.toJSON()` returns a clean object with only ErrorObject properties (no inherited `Error` fields or internal discriminators):
+
+```typescript
+const error = new ErrorObject({ code: "not-found", message: "User not found.", domain: "users" });
+JSON.stringify(error);
+// {"code":"not-found","message":"User not found.","domain":"users"}
+```
+
+## String Output
+
+`.toString()` produces a clean, user-facing string. `.toDebugString()` appends a full JSON dump prefixed with `[DEBUG]`. What `.toString()` includes is configurable:
+
+```typescript
+ErrorObject.INCLUDE_CODE_IN_STRING = true;   // default
+ErrorObject.INCLUDE_DOMAIN_IN_STRING = false; // default
+
+new ErrorObject({ code: "not-found", message: "User not found.", domain: "users" }).toString();
+// "User not found. [not-found]"
+
+ErrorObject.INCLUDE_DOMAIN_IN_STRING = true;
+// "User not found. [users/not-found]"
+```
+
+## Static Configuration
+
+Override these static properties to customize defaults across your app:
+
+```typescript
+// Change the generic error defaults
+ErrorObject.GENERIC_CODE = "error";
+ErrorObject.GENERIC_MESSAGE = "An unexpected error occurred";
+ErrorObject.GENERIC_TAG = "generic-error-object";
+
+// Control what toString() includes
+ErrorObject.INCLUDE_CODE_IN_STRING = true;
+ErrorObject.INCLUDE_DOMAIN_IN_STRING = false;
+
+// Replace the log method (default is console.log)
+ErrorObject.LOG_METHOD = myLogger.error;
+
+// Disable logging entirely
+ErrorObject.LOG_METHOD = null;
+```
+
+## Subclassing
+
+`ErrorObject` is designed to be extended. `instanceof` checks work correctly for derived classes:
+
+```typescript
+class ApiError extends ErrorObject {
+}
+
+const err = new ApiError({ code: "500", message: "Internal server error" });
+err instanceof ApiError;     // true
+err instanceof ErrorObject;  // true
+err instanceof Error;        // true
+```
+
+## Parsing Errors from Any Payload
+
+To create an `ErrorObject` from API responses, caught exceptions, or other unknown payloads,
+see [@smbcheeky/error-object-from-payload](https://github.com/SMBCheeky/error-object-from-payload).
+
+## More Examples
+
+See the [playground](https://github.com/SMBCheeky/error-object/blob/main/playground/index.ts) for runnable examples.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smbcheeky/error-object",
   "description": "Create errors that can be both thrown and returned. Make error handling easier for both JavaScript and TypeScript.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -91,8 +91,7 @@ const runFieldChecks = () => {
     .setDetails("details")
     .debugLog("LOG2")
     .setNumberCode(123)
-    .setRaw({ foo: "bar" })
-    .verboseLog("LOG3");
+    .setRaw({ foo: "bar" });
 
   // [LOG1] Something went wrong. [regular error]
   // [LOG2] Something went wrong. [auth/regular error]
@@ -125,6 +124,24 @@ const runOverrides = () => {
   ErrorObject.GENERIC_CODE = "specific?";
   ErrorObject.GENERIC_MESSAGE = "Something went :(";
 
+  ErrorObject.INCLUDE_CODE_IN_STRING = true;
+  ErrorObject.INCLUDE_DOMAIN_IN_STRING = false;
+
+  ErrorObject.generic().setDomain("should not show").log("LOG").debugLog("LOG");
+
+  ErrorObject.INCLUDE_CODE_IN_STRING = false;
+  ErrorObject.INCLUDE_DOMAIN_IN_STRING = true;
+
+  ErrorObject.generic().setDomain("should show").log("LOG").debugLog("LOG");
+
+  ErrorObject.INCLUDE_CODE_IN_STRING = false;
+  ErrorObject.INCLUDE_DOMAIN_IN_STRING = false;
+
+  ErrorObject.generic()
+    .setDomain("should not show this, should not show code")
+    .log("LOG")
+    .debugLog("LOG");
+
   let objectWithLogic = { complex: true };
 
   ErrorObject.LOG_METHOD = () => {
@@ -139,7 +156,7 @@ const runOverrides = () => {
   // { complex: false } should be { complex: false }
 
   ErrorObject.LOG_METHOD = null as any;
-  ErrorObject.generic().log("LOG").debugLog("LOG").verboseLog("LOG");
+  ErrorObject.generic().log("LOG").debugLog("LOG");
   // should not show anything
 };
 

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -28,7 +28,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@smbcheeky/error-object@file:..":
-  version "1.1.9"
+  version "1.2.1"
   resolved "file:.."
 
 "@tsconfig/node10@^1.0.7":

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * How to check if an object is an ErrorObject:
  *
  *
- *     const errorObject = new ErrorObject.generic();
+ *     const errorObject = ErrorObject.generic();
  *     errorObject instanceof ErrorObject => true
  *     errorObject instanceof Error => true
  *
@@ -19,30 +19,44 @@
  *
  *
  * @extends {Error}
- *
- * @property {string} code - The error code used to identify and resolve the error. It is recommended codes are written to be human-readable, especially for the end-user.
- * @property {string} message - The primary error message.
- * @property {number} [numberCode] - Optional numeric identifier for the error, for cases when the string error code is not sufficient.
- * @property {string} [details] - A detailed error description created for user consumption.
- * @property {string} [domain] - Optional property to categorize the error based on a domain.
- * @property {string} [tag] - Optional property to categorize the error based on a tag.
- * @property [raw] - Can store anything used to create the error.
  */
+
+export interface ErrorObjectParams {
+  /** The error code used to identify and resolve the error. It is recommended codes are written to be human-readable, especially for the end-user. */
+  code: string;
+  /** Optional numeric identifier for the error, for cases when the string error code is not sufficient. */
+  numberCode?: number;
+  /** The primary error message. */
+  message: string;
+  /** A detailed error description created for user consumption. */
+  details?: string;
+  /** Optional property to categorize the error based on a domain. */
+  domain?: string;
+  /** Optional property to categorize the error based on a tag. */
+  tag?: string;
+  /** Can store anything used to create the error. */
+  raw?: any;
+}
+
 export class ErrorObject extends Error {
   readonly __isErrorObjectTypeDiscriminator = true;
 
-  static LOG_METHOD: (...data: any[]) => void = console.log;
+  static LOG_METHOD: ((...data: any[]) => void) | null = console.log;
 
   static GENERIC_CODE = "generic";
   static GENERIC_MESSAGE = "Something went wrong";
   static GENERIC_TAG = "generic-error-object";
 
-  static generic = () =>
-    new this({
+  static INCLUDE_DOMAIN_IN_STRING = false;
+  static INCLUDE_CODE_IN_STRING = true;
+
+  static generic() {
+    return new this({
       code: ErrorObject.GENERIC_CODE,
       message: ErrorObject.GENERIC_MESSAGE,
       tag: ErrorObject.GENERIC_TAG,
     });
+  }
 
   code: string;
   numberCode?: number;
@@ -52,23 +66,7 @@ export class ErrorObject extends Error {
   tag?: string;
   raw?: any;
 
-  constructor({
-    code,
-    numberCode,
-    message,
-    details,
-    domain,
-    tag,
-    raw,
-  }: {
-    code: string;
-    numberCode?: number;
-    message: string;
-    details?: string;
-    domain?: string;
-    tag?: string;
-    raw?: any;
-  }) {
+  constructor({ code, numberCode, message, details, domain, tag, raw }: ErrorObjectParams) {
     super(message);
 
     this.code = code;
@@ -76,28 +74,13 @@ export class ErrorObject extends Error {
     this.message = message;
     this.details = details;
     this.domain = domain;
-
-    // Add logging information
     this.tag = tag;
     this.raw = raw;
 
-    // If you pass another ErrorObject or Error, these may also be useful
-    this.name =
-      this.raw &&
-      typeof this.raw === "object" &&
-      "name" in this.raw &&
-      typeof this.raw.name === "string" &&
-      this.raw.name.length > 0
-        ? this.raw.name
-        : this.code;
-    this.stack =
-      this.raw &&
-      typeof this.raw === "object" &&
-      "stack" in this.raw &&
-      typeof this.raw.stack === "string" &&
-      this.raw.stack.length > 0
-        ? this.raw.stack
-        : undefined;
+    // If you pass another ErrorObject or Error as raw, preserve its name and stack
+    const rawObj = typeof raw === "object" && raw !== null ? raw : undefined;
+    this.name = hasNonEmptyString(rawObj, "name") ? rawObj.name : this.code;
+    this.stack = hasNonEmptyString(rawObj, "stack") ? rawObj.stack : undefined;
 
     // Enable `instanceof` checks
     Object.setPrototypeOf(this, new.target.prototype);
@@ -118,10 +101,17 @@ export class ErrorObject extends Error {
   }
 
   /**
-   * The {@link ErrorObject.new()} method allows users to create a new error object from an existing one, useful when you want to just change the error message.
+   * Creates a new ErrorObject with the same properties as this one.
+   */
+  clone() {
+    return new ErrorObject(this);
+  }
+
+  /**
+   * @deprecated Use {@link ErrorObject.clone()} instead.
    */
   new() {
-    return new ErrorObject(this);
+    return this.clone();
   }
 
   // Setters
@@ -156,53 +146,54 @@ export class ErrorObject extends Error {
     return this;
   }
 
-  setRaw(value?: any | ((old?: any) => any | undefined)) {
+  setRaw(value?: any | ((old?: any) => any)) {
     this.raw = typeof value === "function" ? value(this.raw) : value;
     return this;
   }
 
   // Logging helpers
   toString() {
-    // Create a clean user facing description for error; you might even use it directly in your UI...
-    let extraDomainAndCode = "";
-    let extraDomain = this.domain && this.domain?.length > 0 ? this.domain : "";
-    let extraCode =
+    const showDomain = ErrorObject.INCLUDE_DOMAIN_IN_STRING && !!this.domain;
+    const showCode =
+      ErrorObject.INCLUDE_CODE_IN_STRING &&
       this.code.length > 0 &&
-      (this.domain
-        ? this.domain?.length > 0 && !this.domain.includes(this.code)
-        : true)
-        ? this.code
-        : "";
-    if (extraCode?.length > 0 || extraDomain?.length > 0) {
-      extraDomainAndCode = `[${extraDomain}${
-        extraDomain?.length > 0 && extraCode?.length > 0 ? "/" : ""
-      }${extraCode}]`;
-    }
-    return `${this.message}${
-      extraDomainAndCode?.length > 0 ? " " : ""
-    }${extraDomainAndCode}`;
+      (!showDomain || this.domain !== this.code);
+
+    if (!showDomain && !showCode) return this.message;
+
+    const suffix = showDomain && showCode
+      ? `${this.domain}/${this.code}`
+      : showDomain
+        ? this.domain
+        : this.code;
+
+    return `${this.message} [${suffix}]`;
   }
 
   toDebugString() {
-    return (
-      this.toString() +
-      `\n${JSON.stringify(
-        {
-          code: this.code,
-          numberCode: this.numberCode,
-          message: this.message,
-          details: this.details,
-          domain: this.domain,
-          tag: this.tag,
-        },
-        null,
-        2,
-      )}`
+    const json = JSON.stringify(
+      this,
+      (key, value) => {
+        if (typeof value === "function") return undefined;
+        if (key === "__isErrorObjectTypeDiscriminator") return undefined;
+        return value;
+      },
+      2,
     );
+    return `${this.toString()}\n[DEBUG] ${json}`;
   }
 
-  toVerboseString() {
-    return this.toDebugString() + `\n${JSON.stringify(this.raw, null, 2)}`;
+  toJSON() {
+    const obj: Record<string, unknown> = {
+      code: this.code,
+      message: this.message,
+    };
+    if (this.numberCode !== undefined) obj.numberCode = this.numberCode;
+    if (this.details !== undefined) obj.details = this.details;
+    if (this.domain !== undefined) obj.domain = this.domain;
+    if (this.tag !== undefined) obj.tag = this.tag;
+    if (this.raw !== undefined) obj.raw = this.raw;
+    return obj;
   }
 
   // Log methods
@@ -214,20 +205,11 @@ export class ErrorObject extends Error {
     return this._log(logTag, "debug");
   }
 
-  verboseLog(logTag: string) {
-    return this._log(logTag, "verbose");
-  }
-
-  protected _log(logTag: string, logLevel: "log" | "debug" | "verbose") {
+  protected _log(logTag: string, logLevel: "log" | "debug") {
+    if (!ErrorObject.LOG_METHOD) return this;
     const logForThis =
-      logLevel === "verbose"
-        ? this.toVerboseString()
-        : logLevel === "debug"
-          ? this.toDebugString()
-          : this.toString();
-    ErrorObject.LOG_METHOD &&
-      typeof ErrorObject.LOG_METHOD === "function" &&
-      ErrorObject.LOG_METHOD(`[${logTag}]`, logForThis);
+      logLevel === "debug" ? this.toDebugString() : this.toString();
+    ErrorObject.LOG_METHOD(`[${logTag}]`, logForThis);
     return this;
   }
 
@@ -255,4 +237,16 @@ export class ErrorObject extends Error {
  */
 export function isErrorObject(object: any): object is ErrorObject {
   return ErrorObject.is(object);
+}
+
+function hasNonEmptyString<K extends string>(
+  obj: object | undefined,
+  key: K,
+): obj is Record<K, string> {
+  return (
+    obj !== undefined &&
+    key in obj &&
+    typeof (obj as any)[key] === "string" &&
+    (obj as any)[key].length > 0
+  );
 }


### PR DESCRIPTION
# Changelog

## 1.2.1

### Breaking Changes

- Removed `toVerboseString()` and `verboseLog()` — use `toDebugString()` and `debugLog()` instead

### Added

- `INCLUDE_DOMAIN_IN_STRING` static property to control whether `toString()` includes the domain (default: `false`)
- `INCLUDE_CODE_IN_STRING` static property to control whether `toString()` includes the code (default: `true`)

### Changed

- `toDebugString()` now uses `JSON.stringify(this, ...)` to include all properties dynamically, prefixed with `[DEBUG]`
- `toString()` updated to respect `INCLUDE_DOMAIN_IN_STRING` and `INCLUDE_CODE_IN_STRING`
