### PR TITLE
# Changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .DS_Store
 .npmrc
 .envrc
+/coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.3.0
+
+### Added
+
+- `ResultObject<T>` class for wrapping success values or errors in a single type-safe container
+  - `ResultObject.ok(data)` — create a success result
+  - `ResultObject.err(error)` — create an error result
+  - `.isOk()`, `.isErr()` — type-narrowing guards
+  - `.hasData()`, `.isData()` — aliases for `.isOk()`
+  - `.isError()` — alias for `.isErr()`
+- Unit test suite with Vitest (67 tests, ~99% coverage)
+
 ## 1.2.1
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ while adding structure and ergonomics:
 ## Quick Start
 
 ```typescript
-import { ErrorObject, isErrorObject, ErrorObjectParams } from "@smbcheeky/error-object";
+import { ErrorObject, isErrorObject, ResultObject, ErrorObjectParams } from "@smbcheeky/error-object";
 
 // Create an error
 const error = new ErrorObject({
@@ -216,6 +216,41 @@ err instanceof ApiError;     // true
 err instanceof ErrorObject;  // true
 err instanceof Error;        // true
 ```
+
+## ResultObject
+
+`ResultObject<T>` wraps either a success value or an `ErrorObject`, giving you a type-safe way to return errors instead of throwing them:
+
+```typescript
+import { ResultObject, ErrorObject } from "@smbcheeky/error-object";
+
+function getUser(id: string): ResultObject<User> {
+  if (!id) return ResultObject.err(new ErrorObject({ code: "invalid-id", message: "Missing ID" }));
+  return ResultObject.ok({ name: "Alice" });
+}
+
+const result = getUser("123");
+
+if (result.isOk()) {
+  result.data;  // User — TypeScript narrows the type
+}
+
+if (result.isErr()) {
+  result.error; // ErrorObject
+}
+```
+
+### Guards
+
+All guards narrow the type correctly in TypeScript:
+
+| Method       | Narrows to                               |
+|--------------|------------------------------------------|
+| `.isOk()`    | `{ data: T; error: undefined }`          |
+| `.hasData()` | same as `.isOk()`                        |
+| `.isData()`  | same as `.isOk()`                        |
+| `.isErr()`   | `{ data: undefined; error: ErrorObject }` |
+| `.isError()` | same as `.isErr()`                       |
 
 ## Parsing Errors from Any Payload
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smbcheeky/error-object",
   "description": "Create errors that can be both thrown and returned. Make error handling easier for both JavaScript and TypeScript.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -9,12 +9,15 @@
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "pack": "yarn build && npm pack",
     "release": "yarn build && npm login && npm publish --access public",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "4.1.0",
+    "prettier": "3.7.4",
     "tsup": "8.3.5",
-    "typescript": "^4.9.4",
-    "prettier": "^3.7.4"
+    "typescript": "4.9.5",
+    "vitest": "4.1.0"
   },
   "license": "MIT",
   "private": false,
@@ -32,22 +35,24 @@
     "url": "https://github.com/SMBCheeky/error-object/issues"
   },
   "keywords": [
-    "exceptions",
+    "error",
     "errors",
-    "handling",
-    "try",
-    "throw",
-    "catch",
-    "caught",
-    "instanceof",
-    "debug",
-    "neverthrow",
+    "error-handling",
+    "exception",
     "result",
-    "ok"
+    "result-type",
+    "type-guard",
+    "typescript",
+    "structured-errors",
+    "chainable",
+    "neverthrow",
+    "effect",
+    "error-object"
   ],
   "files": [
     "dist/",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE",
     "package.json"
   ]

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,582 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ErrorObject, isErrorObject, ResultObject } from "./index";
+
+// Reset static config between tests
+beforeEach(() => {
+  ErrorObject.LOG_METHOD = console.log;
+  ErrorObject.GENERIC_CODE = "generic";
+  ErrorObject.GENERIC_MESSAGE = "Something went wrong";
+  ErrorObject.GENERIC_TAG = "generic-error-object";
+  ErrorObject.INCLUDE_DOMAIN_IN_STRING = false;
+  ErrorObject.INCLUDE_CODE_IN_STRING = true;
+});
+
+// ─── Constructor ───
+
+describe("constructor", () => {
+  it("sets all properties from params", () => {
+    const err = new ErrorObject({
+      code: "not-found",
+      message: "User not found",
+      numberCode: 404,
+      details: "No user with that ID exists",
+      domain: "users",
+      tag: "lookup",
+      raw: { id: "abc" },
+    });
+
+    expect(err.code).toBe("not-found");
+    expect(err.message).toBe("User not found");
+    expect(err.numberCode).toBe(404);
+    expect(err.details).toBe("No user with that ID exists");
+    expect(err.domain).toBe("users");
+    expect(err.tag).toBe("lookup");
+    expect(err.raw).toEqual({ id: "abc" });
+  });
+
+  it("sets only required properties", () => {
+    const err = new ErrorObject({ code: "fail", message: "Failed" });
+
+    expect(err.code).toBe("fail");
+    expect(err.message).toBe("Failed");
+    expect(err.numberCode).toBeUndefined();
+    expect(err.details).toBeUndefined();
+    expect(err.domain).toBeUndefined();
+    expect(err.tag).toBeUndefined();
+    expect(err.raw).toBeUndefined();
+  });
+
+  it("sets name to code by default", () => {
+    const err = new ErrorObject({ code: "my-code", message: "msg" });
+    expect(err.name).toBe("my-code");
+  });
+
+  it("preserves name from raw object", () => {
+    const raw = new Error("original");
+    raw.name = "OriginalError";
+    const err = new ErrorObject({ code: "wrapped", message: "msg", raw });
+    expect(err.name).toBe("OriginalError");
+  });
+
+  it("preserves stack from raw object", () => {
+    const raw = new Error("original");
+    const err = new ErrorObject({ code: "wrapped", message: "msg", raw });
+    expect(err.stack).toBe(raw.stack);
+  });
+
+  it("sets stack to undefined when raw has no stack", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    expect(err.stack).toBeUndefined();
+  });
+});
+
+// ─── instanceof ───
+
+describe("instanceof", () => {
+  it("is instanceof ErrorObject", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    expect(err).toBeInstanceOf(ErrorObject);
+  });
+
+  it("is instanceof Error", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("regular Error is not instanceof ErrorObject", () => {
+    const err = new Error("regular");
+    expect(err).not.toBeInstanceOf(ErrorObject);
+  });
+});
+
+// ─── Subclassing ───
+
+describe("subclassing", () => {
+  class ApiError extends ErrorObject {}
+
+  it("subclass is instanceof itself, ErrorObject, and Error", () => {
+    const err = new ApiError({ code: "500", message: "Internal" });
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toBeInstanceOf(ErrorObject);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("ErrorObject is not instanceof subclass", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    expect(err).not.toBeInstanceOf(ApiError);
+  });
+});
+
+// ─── Type Guards ───
+
+describe("type guards", () => {
+  it("ErrorObject.is() returns true for ErrorObject", () => {
+    expect(ErrorObject.is(ErrorObject.generic())).toBe(true);
+  });
+
+  it("ErrorObject.is() returns false for regular Error", () => {
+    expect(ErrorObject.is(new Error("x"))).toBe(false);
+  });
+
+  it("ErrorObject.is() returns false for null/undefined/primitives", () => {
+    expect(ErrorObject.is(null)).toBeFalsy();
+    expect(ErrorObject.is(undefined)).toBeFalsy();
+    expect(ErrorObject.is("string")).toBeFalsy();
+    expect(ErrorObject.is(42)).toBeFalsy();
+  });
+
+  it("ErrorObject.is() returns true for object with discriminator", () => {
+    const fake = { __isErrorObjectTypeDiscriminator: true };
+    expect(ErrorObject.is(fake)).toBe(true);
+  });
+
+  it("isErrorObject() delegates to ErrorObject.is()", () => {
+    expect(isErrorObject(ErrorObject.generic())).toBe(true);
+    expect(isErrorObject(new Error("x"))).toBe(false);
+    expect(isErrorObject(null)).toBeFalsy();
+  });
+});
+
+// ─── Factory Methods ───
+
+describe("factory methods", () => {
+  it("generic() uses default values", () => {
+    const err = ErrorObject.generic();
+    expect(err.code).toBe("generic");
+    expect(err.message).toBe("Something went wrong");
+    expect(err.tag).toBe("generic-error-object");
+  });
+
+  it("generic() respects overridden static defaults", () => {
+    ErrorObject.GENERIC_CODE = "error";
+    ErrorObject.GENERIC_MESSAGE = "Oops";
+    ErrorObject.GENERIC_TAG = "custom-tag";
+
+    const err = ErrorObject.generic();
+    expect(err.code).toBe("error");
+    expect(err.message).toBe("Oops");
+    expect(err.tag).toBe("custom-tag");
+  });
+
+  it("withTag() creates generic error with specific tag", () => {
+    const err = ErrorObject.withTag("network");
+    expect(err.tag).toBe("network");
+    expect(err.code).toBe("generic");
+    expect(err.message).toBe("Something went wrong");
+  });
+});
+
+// ─── isGeneric / hasTag ───
+
+describe("isGeneric and hasTag", () => {
+  it("isGeneric() returns true for generic error", () => {
+    expect(ErrorObject.generic().isGeneric()).toBe(true);
+  });
+
+  it("isGeneric() returns false for non-generic error", () => {
+    const err = new ErrorObject({ code: "c", message: "m", tag: "custom" });
+    expect(err.isGeneric()).toBe(false);
+  });
+
+  it("hasTag() without argument returns true when tag is set", () => {
+    const err = new ErrorObject({ code: "c", message: "m", tag: "x" });
+    expect(err.hasTag()).toBe(true);
+  });
+
+  it("hasTag() without argument returns false when no tag", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    expect(err.hasTag()).toBe(false);
+  });
+
+  it("hasTag(tag) returns true for matching tag", () => {
+    const err = new ErrorObject({ code: "c", message: "m", tag: "x" });
+    expect(err.hasTag("x")).toBe(true);
+  });
+
+  it("hasTag(tag) returns false for non-matching tag", () => {
+    const err = new ErrorObject({ code: "c", message: "m", tag: "x" });
+    expect(err.hasTag("y")).toBe(false);
+  });
+});
+
+// ─── Clone ───
+
+describe("clone", () => {
+  it("creates a copy with same properties", () => {
+    const original = new ErrorObject({
+      code: "c",
+      message: "m",
+      numberCode: 1,
+      details: "d",
+      domain: "dom",
+      tag: "t",
+      raw: { x: 1 },
+    });
+    const cloned = original.clone();
+
+    expect(cloned.code).toBe(original.code);
+    expect(cloned.message).toBe(original.message);
+    expect(cloned.numberCode).toBe(original.numberCode);
+    expect(cloned.details).toBe(original.details);
+    expect(cloned.domain).toBe(original.domain);
+    expect(cloned.tag).toBe(original.tag);
+    expect(cloned.raw).toEqual(original.raw);
+  });
+
+  it("clone is independent from original", () => {
+    const original = new ErrorObject({ code: "c", message: "m" });
+    const cloned = original.clone();
+    cloned.setCode("changed");
+    expect(original.code).toBe("c");
+  });
+
+  it("new() is an alias for clone()", () => {
+    const original = new ErrorObject({ code: "c", message: "m" });
+    const cloned = original.new();
+    expect(cloned.code).toBe("c");
+    expect(cloned.message).toBe("m");
+  });
+});
+
+// ─── Chainable Setters ───
+
+describe("chainable setters", () => {
+  it("all setters return this", () => {
+    const err = ErrorObject.generic();
+    expect(err.setCode("x")).toBe(err);
+    expect(err.setMessage("x")).toBe(err);
+    expect(err.setNumberCode(1)).toBe(err);
+    expect(err.setDetails("x")).toBe(err);
+    expect(err.setDomain("x")).toBe(err);
+    expect(err.setTag("x")).toBe(err);
+    expect(err.setRaw("x")).toBe(err);
+  });
+
+  it("setters accept direct values", () => {
+    const err = ErrorObject.generic()
+      .setCode("new-code")
+      .setMessage("new msg")
+      .setNumberCode(500)
+      .setDetails("detail")
+      .setDomain("dom")
+      .setTag("tag")
+      .setRaw({ key: "val" });
+
+    expect(err.code).toBe("new-code");
+    expect(err.message).toBe("new msg");
+    expect(err.numberCode).toBe(500);
+    expect(err.details).toBe("detail");
+    expect(err.domain).toBe("dom");
+    expect(err.tag).toBe("tag");
+    expect(err.raw).toEqual({ key: "val" });
+  });
+
+  it("setters accept transform functions", () => {
+    const err = new ErrorObject({ code: "old", message: "hello" });
+    err.setCode((old) => old + "-new");
+    err.setMessage((old) => old + " world");
+    expect(err.code).toBe("old-new");
+    expect(err.message).toBe("hello world");
+  });
+
+  it("setNumberCode transform receives undefined when unset", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    err.setNumberCode((old) => (old ?? 0) + 1);
+    expect(err.numberCode).toBe(1);
+  });
+
+  it("setDetails accepts transform function", () => {
+    const err = new ErrorObject({ code: "c", message: "m", details: "old" });
+    err.setDetails((old) => old + "-new");
+    expect(err.details).toBe("old-new");
+  });
+
+  it("setDomain accepts transform function", () => {
+    const err = new ErrorObject({ code: "c", message: "m", domain: "old" });
+    err.setDomain((old) => old + "-new");
+    expect(err.domain).toBe("old-new");
+  });
+
+  it("setTag accepts transform function", () => {
+    const err = new ErrorObject({ code: "c", message: "m", tag: "old" });
+    err.setTag((old) => old + "-new");
+    expect(err.tag).toBe("old-new");
+  });
+
+  it("setRaw accepts transform function", () => {
+    const err = new ErrorObject({ code: "c", message: "m", raw: { a: 1 } });
+    err.setRaw((old: any) => ({ ...old, b: 2 }));
+    expect(err.raw).toEqual({ a: 1, b: 2 });
+  });
+
+  it("setters can clear optional properties with undefined", () => {
+    const err = new ErrorObject({
+      code: "c",
+      message: "m",
+      details: "d",
+      domain: "dom",
+      tag: "t",
+      numberCode: 1,
+    });
+    err.setDetails(undefined).setDomain(undefined).setTag(undefined).setNumberCode(undefined);
+    expect(err.details).toBeUndefined();
+    expect(err.domain).toBeUndefined();
+    expect(err.tag).toBeUndefined();
+    expect(err.numberCode).toBeUndefined();
+  });
+});
+
+// ─── toString ───
+
+describe("toString", () => {
+  it("includes code by default", () => {
+    const err = new ErrorObject({ code: "not-found", message: "Not found" });
+    expect(err.toString()).toBe("Not found [not-found]");
+  });
+
+  it("returns only message when INCLUDE_CODE_IN_STRING is false", () => {
+    ErrorObject.INCLUDE_CODE_IN_STRING = false;
+    const err = new ErrorObject({ code: "c", message: "msg" });
+    expect(err.toString()).toBe("msg");
+  });
+
+  it("includes domain when INCLUDE_DOMAIN_IN_STRING is true", () => {
+    ErrorObject.INCLUDE_DOMAIN_IN_STRING = true;
+    const err = new ErrorObject({ code: "c", message: "msg", domain: "auth" });
+    expect(err.toString()).toBe("msg [auth/c]");
+  });
+
+  it("deduplicates when domain equals code", () => {
+    ErrorObject.INCLUDE_DOMAIN_IN_STRING = true;
+    const err = new ErrorObject({ code: "auth", message: "msg", domain: "auth" });
+    expect(err.toString()).toBe("msg [auth]");
+  });
+
+  it("shows only domain when code is disabled", () => {
+    ErrorObject.INCLUDE_CODE_IN_STRING = false;
+    ErrorObject.INCLUDE_DOMAIN_IN_STRING = true;
+    const err = new ErrorObject({ code: "c", message: "msg", domain: "auth" });
+    expect(err.toString()).toBe("msg [auth]");
+  });
+
+  it("returns only message when both are disabled", () => {
+    ErrorObject.INCLUDE_CODE_IN_STRING = false;
+    ErrorObject.INCLUDE_DOMAIN_IN_STRING = false;
+    const err = new ErrorObject({ code: "c", message: "msg", domain: "auth" });
+    expect(err.toString()).toBe("msg");
+  });
+
+  it("returns only message when code is empty string", () => {
+    const err = new ErrorObject({ code: "", message: "msg" });
+    expect(err.toString()).toBe("msg");
+  });
+});
+
+// ─── toJSON ───
+
+describe("toJSON", () => {
+  it("includes only set properties", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    expect(err.toJSON()).toEqual({ code: "c", message: "m" });
+  });
+
+  it("includes all properties when set", () => {
+    const err = new ErrorObject({
+      code: "c",
+      message: "m",
+      numberCode: 1,
+      details: "d",
+      domain: "dom",
+      tag: "t",
+      raw: "r",
+    });
+    expect(err.toJSON()).toEqual({
+      code: "c",
+      message: "m",
+      numberCode: 1,
+      details: "d",
+      domain: "dom",
+      tag: "t",
+      raw: "r",
+    });
+  });
+
+  it("does not include __isErrorObjectTypeDiscriminator", () => {
+    const json = ErrorObject.generic().toJSON();
+    expect(json).not.toHaveProperty("__isErrorObjectTypeDiscriminator");
+  });
+});
+
+// ─── toDebugString ───
+
+describe("toDebugString", () => {
+  it("starts with toString() and includes [DEBUG] JSON", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    const debug = err.toDebugString();
+    expect(debug).toContain("m [c]");
+    expect(debug).toContain("[DEBUG]");
+    expect(debug).toContain('"code": "c"');
+    expect(debug).toContain('"message": "m"');
+  });
+
+  it("excludes __isErrorObjectTypeDiscriminator from JSON", () => {
+    const debug = ErrorObject.generic().toDebugString();
+    expect(debug).not.toContain("__isErrorObjectTypeDiscriminator");
+  });
+
+  it("excludes __isErrorObjectTypeDiscriminator even when it is the only extra property", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    // Verify the discriminator exists on the instance
+    expect((err as any).__isErrorObjectTypeDiscriminator).toBe(true);
+    const debug = err.toDebugString();
+    // The replacer on line 178 should filter it out
+    expect(debug).not.toContain("__isErrorObjectTypeDiscriminator");
+    // But other keys should remain
+    expect(debug).toContain('"code"');
+    expect(debug).toContain('"message"');
+  });
+
+  it("excludes function properties from JSON", () => {
+    const err = new ErrorObject({ code: "c", message: "m", raw: { fn: () => {} } });
+    const debug = err.toDebugString();
+    expect(debug).not.toContain('"fn"');
+  });
+});
+
+// ─── Logging ───
+
+describe("logging", () => {
+  it("log() calls LOG_METHOD with tag and toString()", () => {
+    const spy = vi.fn();
+    ErrorObject.LOG_METHOD = spy;
+    const err = new ErrorObject({ code: "c", message: "m" });
+    err.log("TAG");
+    expect(spy).toHaveBeenCalledWith("[TAG]", "m [c]");
+  });
+
+  it("debugLog() calls LOG_METHOD with tag and toDebugString()", () => {
+    const spy = vi.fn();
+    ErrorObject.LOG_METHOD = spy;
+    const err = new ErrorObject({ code: "c", message: "m" });
+    err.debugLog("TAG");
+    expect(spy).toHaveBeenCalledWith("[TAG]", err.toDebugString());
+  });
+
+  it("log() returns this for chaining", () => {
+    ErrorObject.LOG_METHOD = vi.fn();
+    const err = ErrorObject.generic();
+    expect(err.log("X")).toBe(err);
+  });
+
+  it("debugLog() returns this for chaining", () => {
+    ErrorObject.LOG_METHOD = vi.fn();
+    const err = ErrorObject.generic();
+    expect(err.debugLog("X")).toBe(err);
+  });
+
+  it("does not call LOG_METHOD when it is null", () => {
+    ErrorObject.LOG_METHOD = null;
+    const err = ErrorObject.generic();
+    expect(() => err.log("X")).not.toThrow();
+    expect(() => err.debugLog("X")).not.toThrow();
+  });
+});
+
+// ─── Throwing and Catching ───
+
+describe("throw and catch", () => {
+  it("can be thrown and caught", () => {
+    const err = new ErrorObject({ code: "c", message: "m" });
+    expect(() => {
+      throw err;
+    }).toThrow(err);
+  });
+
+  it("caught error is instanceof ErrorObject", () => {
+    try {
+      throw new ErrorObject({ code: "c", message: "m" });
+    } catch (e) {
+      expect(e).toBeInstanceOf(ErrorObject);
+      expect(e).toBeInstanceOf(Error);
+    }
+  });
+});
+
+// ─── ResultObject ───
+
+describe("ResultObject", () => {
+  describe("ok", () => {
+    it("creates a success result with data", () => {
+      const result = ResultObject.ok({ name: "Alice" });
+      expect(result.data).toEqual({ name: "Alice" });
+      expect(result.error).toBeUndefined();
+    });
+
+    it("works with primitive values", () => {
+      expect(ResultObject.ok(42).data).toBe(42);
+      expect(ResultObject.ok("hello").data).toBe("hello");
+      expect(ResultObject.ok(true).data).toBe(true);
+      expect(ResultObject.ok(null).data).toBe(null);
+    });
+  });
+
+  describe("err", () => {
+    it("creates an error result with ErrorObject", () => {
+      const error = ErrorObject.generic();
+      const result = ResultObject.err(error);
+      expect(result.error).toBe(error);
+      expect(result.data).toBeUndefined();
+    });
+  });
+
+  describe("isOk / hasData / isData", () => {
+    it("returns true for success result", () => {
+      const result = ResultObject.ok("value");
+      expect(result.isOk()).toBe(true);
+      expect(result.hasData()).toBe(true);
+      expect(result.isData()).toBe(true);
+    });
+
+    it("returns false for error result", () => {
+      const result = ResultObject.err(ErrorObject.generic());
+      expect(result.isOk()).toBe(false);
+      expect(result.hasData()).toBe(false);
+      expect(result.isData()).toBe(false);
+    });
+  });
+
+  describe("isErr / isError", () => {
+    it("returns true for error result", () => {
+      const result = ResultObject.err(ErrorObject.generic());
+      expect(result.isErr()).toBe(true);
+      expect(result.isError()).toBe(true);
+    });
+
+    it("returns false for success result", () => {
+      const result = ResultObject.ok("value");
+      expect(result.isErr()).toBe(false);
+      expect(result.isError()).toBe(false);
+    });
+  });
+
+  describe("type narrowing", () => {
+    it("narrows data after isOk()", () => {
+      const result: ResultObject<{ name: string }> = ResultObject.ok({ name: "Alice" });
+      if (result.isOk()) {
+        // If this compiles, type narrowing works
+        const name: string = result.data.name;
+        expect(name).toBe("Alice");
+      }
+    });
+
+    it("narrows error after isErr()", () => {
+      const result: ResultObject<string> = ResultObject.err(
+        new ErrorObject({ code: "fail", message: "Failed" }),
+      );
+      if (result.isErr()) {
+        const code: string = result.error.code;
+        expect(code).toBe("fail");
+      }
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,53 @@ export function isErrorObject(object: any): object is ErrorObject {
   return ErrorObject.is(object);
 }
 
+/**
+ * A {@link ResultObject} wraps either a success value or an {@link ErrorObject}.
+ *
+ *     const result = ResultObject.ok({ name: "Alice" });
+ *     if (result.isOk()) result.data; // { name: "Alice" }
+ *
+ *     const error = ResultObject.err(ErrorObject.generic());
+ *     if (error.isErr()) error.error; // ErrorObject
+ */
+export class ResultObject<T> {
+  readonly data?: T;
+  readonly error?: ErrorObject;
+
+  private constructor(data?: T, error?: ErrorObject) {
+    this.data = data;
+    this.error = error;
+  }
+
+  static ok<T>(data: T): ResultObject<T> {
+    return new ResultObject(data, undefined);
+  }
+
+  static err<T = never>(error: ErrorObject): ResultObject<T> {
+    return new ResultObject<T>(undefined, error);
+  }
+
+  isOk(): this is ResultObject<T> & { data: T; error: undefined } {
+    return this.error === undefined;
+  }
+
+  hasData(): this is ResultObject<T> & { data: T; error: undefined } {
+    return this.isOk();
+  }
+
+  isData(): this is ResultObject<T> & { data: T; error: undefined } {
+    return this.isOk();
+  }
+
+  isErr(): this is ResultObject<T> & { data: undefined; error: ErrorObject } {
+    return this.error !== undefined;
+  }
+
+  isError(): this is ResultObject<T> & { data: undefined; error: ErrorObject } {
+    return this.isErr();
+  }
+}
+
 function hasNonEmptyString<K extends string>(
   obj: object | undefined,
   key: K,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,58 @@
 # yarn lockfile v1
 
 
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
+"@babel/helper-validator-identifier@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
+  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/parser@^7.29.0":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.2.tgz#58bd50b9a7951d134988a1ae177a35ef9a703ba1"
+  integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
+  dependencies:
+    "@babel/types" "^7.29.0"
+
+"@babel/types@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
+
+"@bcoe/v8-coverage@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
+  integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
+
+"@emnapi/core@^1.7.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
+  integrity sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.0"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.7.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.1.tgz#115ff2a0d589865be6bd8e9d701e499c473f2a8d"
+  integrity sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
+  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@esbuild/aix-ppc64@0.24.2":
   version "0.24.2"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz#38848d3e25afe842a7943643cbcd387cc6e13461"
@@ -151,6 +203,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@jridgewell/trace-mapping@^0.3.24":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
@@ -158,6 +215,110 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.31":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@napi-rs/wasm-runtime@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz#c3705ab549d176b8dc5172723d6156c3dc426af2"
+  integrity sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==
+  dependencies:
+    "@emnapi/core" "^1.7.1"
+    "@emnapi/runtime" "^1.7.1"
+    "@tybys/wasm-util" "^0.10.1"
+
+"@oxc-project/types@=0.120.0":
+  version "0.120.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.120.0.tgz#af521b0e689dd0eaa04fe4feef9b68d98b74783d"
+  integrity sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==
+
+"@rolldown/binding-android-arm64@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz#0bbd3380f49a6d0dc96c9b32fb7dad26ae0dfaa7"
+  integrity sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==
+
+"@rolldown/binding-darwin-arm64@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz#a30b051784fbb13635e652ba4041c6ce7a4ce7ab"
+  integrity sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==
+
+"@rolldown/binding-darwin-x64@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz#2d9dea982d5be90b95b6d8836ff26a4b0959d94b"
+  integrity sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==
+
+"@rolldown/binding-freebsd-x64@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz#4efc3aca43ae4dfb90729eeca6e84ef6e6b38c4a"
+  integrity sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz#4a19a5d24537e925b25e9583b6cd575b2ad9fa27"
+  integrity sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==
+
+"@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz#01a41e5e905838353ae9a3da10dc8242dcd61453"
+  integrity sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==
+
+"@rolldown/binding-linux-arm64-musl@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz#bd059e5f83471de29ce35b0ba254995d8091ca40"
+  integrity sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==
+
+"@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz#fe726a540631015f269a989c0cfb299283190390"
+  integrity sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==
+
+"@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz#825ced028bad3f1fa9ce83b1f3dac76e0424367f"
+  integrity sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==
+
+"@rolldown/binding-linux-x64-gnu@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz#b700dae69274aa3d54a16ca5e00e30f47a089119"
+  integrity sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==
+
+"@rolldown/binding-linux-x64-musl@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz#eb875660ad68a2348acab36a7005699e87f6e9dd"
+  integrity sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==
+
+"@rolldown/binding-openharmony-arm64@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz#72aa24b412f83025087bcf83ce09634b2bd93c5c"
+  integrity sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==
+
+"@rolldown/binding-wasm32-wasi@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz#7f3303a96c5dc01d1f4c539b1dcbc16392c6f17d"
+  integrity sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^1.1.1"
+
+"@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz#3419144a04ad12c69c48536b01fc21ac9d87ecf4"
+  integrity sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==
+
+"@rolldown/binding-win32-x64-msvc@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz#09bee46e6a32c6086beeabc3da12e67be714f882"
+  integrity sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==
+
+"@rolldown/pluginutils@1.0.0-rc.10":
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz#eed997f37f928a3300bbe2161f42687d8a3ae759"
+  integrity sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==
 
 "@rollup/rollup-android-arm-eabi@4.55.1":
   version "4.55.1"
@@ -284,15 +445,130 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz#f79437939020b83057faf07e98365b1fa51c458b"
   integrity sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==
 
-"@types/estree@1.0.8":
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@tybys/wasm-util@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
+  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
+
+"@types/estree@1.0.8", "@types/estree@^1.0.0":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@vitest/coverage-v8@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz#7ef70bc23e588564fd0ff7e755cbdcd627de8e6c"
+  integrity sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==
+  dependencies:
+    "@bcoe/v8-coverage" "^1.0.2"
+    "@vitest/utils" "4.1.0"
+    ast-v8-to-istanbul "^1.0.0"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.2.0"
+    magicast "^0.5.2"
+    obug "^2.1.1"
+    std-env "^4.0.0-rc.1"
+    tinyrainbow "^3.0.3"
+
+"@vitest/expect@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.0.tgz#2f6c7d19cfbe778bfb42d73f77663ec22163fcbb"
+  integrity sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.0"
+    "@vitest/utils" "4.1.0"
+    chai "^6.2.2"
+    tinyrainbow "^3.0.3"
+
+"@vitest/mocker@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.0.tgz#2aabf6079ad472f89a212d322f7d5da7ad628a0e"
+  integrity sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==
+  dependencies:
+    "@vitest/spy" "4.1.0"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.0.tgz#b6ccf2868130a647d24af3696d58c09a95eb83c1"
+  integrity sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==
+  dependencies:
+    tinyrainbow "^3.0.3"
+
+"@vitest/runner@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.0.tgz#4e12c0f086eb3a4ae3fae84d9d68b22d02942cbf"
+  integrity sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==
+  dependencies:
+    "@vitest/utils" "4.1.0"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.0.tgz#67372979da692ccf5dfa4a3bb603f683c0640202"
+  integrity sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==
+  dependencies:
+    "@vitest/pretty-format" "4.1.0"
+    "@vitest/utils" "4.1.0"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.0.tgz#b9143a63cca83de34ac1777c733f8561b73fa9ba"
+  integrity sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==
+
+"@vitest/utils@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.0.tgz#2baf26a2a28c4aabe336315dc59722df2372c38d"
+  integrity sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==
+  dependencies:
+    "@vitest/pretty-format" "4.1.0"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.0.3"
 
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+ast-v8-to-istanbul@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz#d1e8bfc79fa9c452972ff91897633bda4e5e7577"
+  integrity sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.31"
+    estree-walker "^3.0.3"
+    js-tokens "^10.0.0"
 
 bundle-require@^5.0.0:
   version "5.1.0"
@@ -305,6 +581,11 @@ cac@^6.7.14:
   version "6.7.14"
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
   integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chokidar@^4.0.1:
   version "4.0.3"
@@ -323,12 +604,27 @@ consola@^3.2.3:
   resolved "https://registry.yarnpkg.com/consola/-/consola-3.4.2.tgz#5af110145397bb67afdab77013fdc34cae590ea7"
   integrity sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==
 
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
 debug@^4.3.7:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
+
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+es-module-lexer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.0.0.tgz#f657cd7a9448dcdda9c070a3cb75e5dc1e85f5b1"
+  integrity sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==
 
 esbuild@^0.24.0:
   version "0.24.2"
@@ -361,20 +657,143 @@ esbuild@^0.24.0:
     "@esbuild/win32-ia32" "0.24.2"
     "@esbuild/win32-x64" "0.24.2"
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
+expect-type@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
+
 fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-reports@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 joycon@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
+
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
+
+lightningcss-android-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
+  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
+
+lightningcss-darwin-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz#50b71871b01c8199584b649e292547faea7af9b5"
+  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+
+lightningcss-darwin-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
+  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
+
+lightningcss-freebsd-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
+  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
+
+lightningcss-linux-arm-gnueabihf@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
+  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
+
+lightningcss-linux-arm64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
+  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
+
+lightningcss-linux-arm64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
+  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
+
+lightningcss-linux-x64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
+  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
+  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
+
+lightningcss-win32-arm64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
+  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
+
+lightningcss-win32-x64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
+  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+
+lightningcss@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.32.0.tgz#b85aae96486dcb1bf49a7c8571221273f4f1e4a9"
+  integrity sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.32.0"
+    lightningcss-darwin-arm64 "1.32.0"
+    lightningcss-darwin-x64 "1.32.0"
+    lightningcss-freebsd-x64 "1.32.0"
+    lightningcss-linux-arm-gnueabihf "1.32.0"
+    lightningcss-linux-arm64-gnu "1.32.0"
+    lightningcss-linux-arm64-musl "1.32.0"
+    lightningcss-linux-x64-gnu "1.32.0"
+    lightningcss-linux-x64-musl "1.32.0"
+    lightningcss-win32-arm64-msvc "1.32.0"
+    lightningcss-win32-x64-msvc "1.32.0"
 
 lilconfig@^3.1.1:
   version "3.1.3"
@@ -396,6 +815,29 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+
+magicast@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.5.2.tgz#70cea9df729c164485049ea5df85a390281dfb9d"
+  integrity sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==
+  dependencies:
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    source-map-js "^1.2.1"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -410,10 +852,25 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
 object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+obug@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
+  integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
+
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -437,7 +894,16 @@ postcss-load-config@^6.0.1:
   dependencies:
     lilconfig "^3.1.1"
 
-prettier@^3.7.4:
+postcss@^8.5.8:
+  version "8.5.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.8.tgz#6230ecc8fb02e7a0f6982e53990937857e13f399"
+  integrity sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+prettier@3.7.4:
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.7.4.tgz#d2f8335d4b1cec47e1c8098645411b0c9dff9c0f"
   integrity sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==
@@ -456,6 +922,30 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+rolldown@1.0.0-rc.10:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.0.0-rc.10.tgz#41c55e52d833c52c90131973047250548e35f2bf"
+  integrity sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==
+  dependencies:
+    "@oxc-project/types" "=0.120.0"
+    "@rolldown/pluginutils" "1.0.0-rc.10"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.0.0-rc.10"
+    "@rolldown/binding-darwin-arm64" "1.0.0-rc.10"
+    "@rolldown/binding-darwin-x64" "1.0.0-rc.10"
+    "@rolldown/binding-freebsd-x64" "1.0.0-rc.10"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.0.0-rc.10"
+    "@rolldown/binding-linux-arm64-gnu" "1.0.0-rc.10"
+    "@rolldown/binding-linux-arm64-musl" "1.0.0-rc.10"
+    "@rolldown/binding-linux-ppc64-gnu" "1.0.0-rc.10"
+    "@rolldown/binding-linux-s390x-gnu" "1.0.0-rc.10"
+    "@rolldown/binding-linux-x64-gnu" "1.0.0-rc.10"
+    "@rolldown/binding-linux-x64-musl" "1.0.0-rc.10"
+    "@rolldown/binding-openharmony-arm64" "1.0.0-rc.10"
+    "@rolldown/binding-wasm32-wasi" "1.0.0-rc.10"
+    "@rolldown/binding-win32-arm64-msvc" "1.0.0-rc.10"
+    "@rolldown/binding-win32-x64-msvc" "1.0.0-rc.10"
 
 rollup@^4.24.0:
   version "4.55.1"
@@ -491,12 +981,37 @@ rollup@^4.24.0:
     "@rollup/rollup-win32-x64-msvc" "4.55.1"
     fsevents "~2.3.2"
 
+semver@^7.5.3:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map@0.8.0-beta.0:
   version "0.8.0-beta.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
   integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
   dependencies:
     whatwg-url "^7.0.0"
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^4.0.0-rc.1:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.0.0.tgz#ba3dc31c3a46bc5ba21138aa20a6a4ceb5bb9b7e"
+  integrity sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==
 
 sucrase@^3.35.0:
   version "3.35.1"
@@ -510,6 +1025,13 @@ sucrase@^3.35.0:
     pirates "^4.0.1"
     tinyglobby "^0.2.11"
     ts-interface-checker "^0.1.9"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 thenify-all@^1.0.0:
   version "1.6.0"
@@ -525,18 +1047,33 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
 tinyexec@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinyglobby@^0.2.11, tinyglobby@^0.2.9:
+tinyexec@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.0.4.tgz#6c60864fe1d01331b2f17c6890f535d7e5385408"
+  integrity sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==
+
+tinyglobby@^0.2.11, tinyglobby@^0.2.15, tinyglobby@^0.2.9:
   version "0.2.15"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
   integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.3"
+
+tinyrainbow@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
+  integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
 tr46@^1.0.1:
   version "1.0.1"
@@ -554,6 +1091,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsup@8.3.5:
   version "8.3.5"
@@ -577,10 +1119,49 @@ tsup@8.3.5:
     tinyglobby "^0.2.9"
     tree-kill "^1.2.2"
 
-typescript@^4.9.4:
+typescript@4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0-0":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.1.tgz#015cef9a747c07c0cf9cf553f37571885504e9d3"
+  integrity sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==
+  dependencies:
+    lightningcss "^1.32.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.8"
+    rolldown "1.0.0-rc.10"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.0.tgz#b598abbe83f0c9e93d18cf3c5f23c75a525f8e82"
+  integrity sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==
+  dependencies:
+    "@vitest/expect" "4.1.0"
+    "@vitest/mocker" "4.1.0"
+    "@vitest/pretty-format" "4.1.0"
+    "@vitest/runner" "4.1.0"
+    "@vitest/snapshot" "4.1.0"
+    "@vitest/spy" "4.1.0"
+    "@vitest/utils" "4.1.0"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.0.3"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+    why-is-node-running "^2.3.0"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -595,3 +1176,11 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"


### PR DESCRIPTION
## 1.3.0

### Added

- `ResultObject<T>` class for wrapping success values or errors in a single type-safe container
  - `ResultObject.ok(data)` — create a success result
  - `ResultObject.err(error)` — create an error result
  - `.isOk()`, `.isErr()` — type-narrowing guards
  - `.hasData()`, `.isData()` — aliases for `.isOk()`
  - `.isError()` — alias for `.isErr()`
- Unit test suite with Vitest (67 tests, ~99% coverage)